### PR TITLE
feat: Use registry image instead of docker image

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -1,7 +1,7 @@
 ---
 resource_types:
   - name: pull-request
-    type: docker-image
+    type: registry-image
     source:
       repository: mirror.gcr.io/teliaoss/github-pr-resource
       username: _json_key
@@ -53,7 +53,7 @@ resources:
       private_key: ((github.private_key))
 
   - name: node
-    type: docker-image
+    type: registry-image
     icon: docker
     source:
       repository: mirror.gcr.io/node


### PR DESCRIPTION
- In order to use gcr mirror had to change the resource type from docker to registry

Authored-by: Ramkumar Vengadakrishnan <ramkumar.vengadakrishnan@broadcom.com>